### PR TITLE
added component breadcrumb

### DIFF
--- a/src/components/MaterializeBreadcrumb.vue
+++ b/src/components/MaterializeBreadcrumb.vue
@@ -1,0 +1,9 @@
+<template lang="pug">
+    nav
+        .nav-wrapper
+            .col.s12
+                slot
+</template>
+<script>
+export default {};
+</script>

--- a/src/components/MaterializeBreadcrumb.vue
+++ b/src/components/MaterializeBreadcrumb.vue
@@ -1,8 +1,11 @@
-<template lang="pug">
-    nav
-        .nav-wrapper
-            .col.s12
-                slot
+<template>
+  <nav>
+    <div class="nav-wrapper">
+      <div class="col s12">
+        <slot />
+      </div>
+    </div>
+  </nav>
 </template>
 <script>
 export default {};


### PR DESCRIPTION
This component is the parent part of the [Materialize CSS breadcrumb component](https://materializecss.com/breadcrumbs.html).

Usage:

```html
<materialize-breadcrumb>
  <!-- ... -->
</materialize-breadcrumb>
```