### PR TITLE
added component breadcrumb item

### DIFF
--- a/src/components/MaterializeBreadcrumbItem.vue
+++ b/src/components/MaterializeBreadcrumbItem.vue
@@ -1,0 +1,17 @@
+<template lang="pug">
+    div
+        router-link.breadcrumb(v-if="router")
+            slot
+        a.breadcrumb(v-else)
+            slot
+</template>
+<script>
+export default {
+  props: {
+    router: {
+      type: Boolean,
+      default: false
+    }
+  }
+};
+</script>

--- a/src/components/MaterializeBreadcrumbItem.vue
+++ b/src/components/MaterializeBreadcrumbItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <router-link v-if="router" class="breadcrumb">
+    <router-link v-if="to" class="breadcrumb">
       <slot />
     </router-link>
     <a v-else class="breadcrumb">
@@ -9,12 +9,5 @@
   </div>
 </template>
 <script>
-export default {
-  props: {
-    router: {
-      type: Boolean,
-      default: false
-    }
-  }
-};
+export default {};
 </script>

--- a/src/components/MaterializeBreadcrumbItem.vue
+++ b/src/components/MaterializeBreadcrumbItem.vue
@@ -1,9 +1,12 @@
-<template lang="pug">
-    div
-        router-link.breadcrumb(v-if="router")
-            slot
-        a.breadcrumb(v-else)
-            slot
+<template>
+  <div>
+    <router-link v-if="router" class="breadcrumb">
+      <slot />
+    </router-link>
+    <a v-else class="breadcrumb">
+      <slot />
+    </a>
+  </div>
 </template>
 <script>
 export default {


### PR DESCRIPTION
This component is the items of the [Materialize CSS Breadcrumb component](https://materializecss.com/breadcrumbs.html).

Usage (without VueRouter, produces `<a>` tags):

```html
<materialize-breadcrumb>
  <materialize-breadcrumb-item href="/">Home</materialize-breadcrumb-item>
  <materialize-breadcrumb-item href="/about">About</materialize-breadcrumb-item>
</materialize-breadcrumb>
```

Usage (with VueRouter, produces `<router-link>` tags):

```html
<materialize-breadcrumb>
  <materialize-breadcrumb-item to="/">Home</materialize-breadcrumb-item>
  <materialize-breadcrumb-item to="/about">About</materialize-breadcrumb-item>
</materialize-breadcrumb>
```