### PR TITLE
Add scroll spy to doc

### DIFF
--- a/docs/docs.js
+++ b/docs/docs.js
@@ -13,18 +13,22 @@ window.addEventListener("load", () => {
         data: {
             components: [
                 {
+                    slug: "icon",
                     code: '<materialize-icon icon="face" />',
                     name: "Icon"
                 },
                 {
+                    slug: "brand-logo",
                     code: "<materialize-brand-logo>Application Name</materialize-brand-logo>",
                     name: "Brand Logo"
                 },
                 {
+                    slug: "breadcrumb",
                     code: "<materialize-breadcrumb>\n    <!-- breadcrumb items here -->\n</materialize-breadcrumb>",
                     name: "Breadcrumb"
                 },
                 {
+                    slug: "breadcrumb-item",
                     code: '<materialize-breadcrumb-item>Home</materialize-breadcrumb-item>\n<materialize-breadcrumb-item to="products">Products</materialize-breadcrumb-item>',
                     name: "Breadcrumb Item"
                 }
@@ -35,6 +39,8 @@ window.addEventListener("load", () => {
         mounted() {
             // eslint-disable-next-line
             Prism.highlightAll();
+            M.ScrollSpy.init(document.querySelectorAll(".scrollspy"));
+            M.Pushpin.init(document.querySelector("#fixed-navigation"));
         }
     });
 });

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en-US">
 	<head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<link rel="stylesheet" href="https://unpkg.com/materialize-css/dist/css/materialize.min.css" />
 		<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.16.0/themes/prism.min.css" />
@@ -10,7 +12,7 @@
 		<div id="example">
 			<div class="container">
 				<div class="row">
-                    <div class="col s10">
+                    <div class="col s12 m10 l10 xl10">
                         <div class="row">
                             <div class="col s12 section scrollspy" v-for="component in sortedComponents" :id="component.slug">
                                 <h2>{{ component.name }}</h2>
@@ -18,7 +20,7 @@
                             </div>
                         </div>
                     </div>
-					<div class="col s2 hide-on-small-only">
+					<div class="col m2 l2 xl2 hide-on-small-only">
 						<ul class="section table-of-contents" id="fixed-navigation">
 							<li v-for="component in sortedComponents">
                                 <a :href="`#${component.slug}`">{{ component.name }}</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,26 +1,37 @@
 <!DOCTYPE html>
 <html lang="en-US">
-    <head>
-        <link rel="stylesheet" href="https://unpkg.com/materialize-css/dist/css/materialize.min.css" />
-        <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.16.0/themes/prism.min.css" />
-        <title>Example</title>
-    </head>
-    <body>
-        <div id="example">
-            <div class="container">
-                <div class="row">
-                    <div class="col s12" v-for="component in sortedComponents">
-                        <h2>{{ component.name }}</h2>
-                        <pre><code class="language-html">{{ component.code }}</code></pre>
+	<head>
+		<link rel="stylesheet" href="https://unpkg.com/materialize-css/dist/css/materialize.min.css" />
+		<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.16.0/themes/prism.min.css" />
+		<title>Example</title>
+	</head>
+	<body>
+		<div id="example">
+			<div class="container">
+				<div class="row">
+                    <div class="col s10">
+                        <div class="row">
+                            <div class="col s12 section scrollspy" v-for="component in sortedComponents" :id="component.slug">
+                                <h2>{{ component.name }}</h2>
+                                <pre><code class="language-html">{{ component.code }}</code></pre>
+                            </div>
+                        </div>
                     </div>
-                </div>
-            </div>
-        </div>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.16.0/prism.js"></script>
-        <script src="https://unpkg.com/materialize-css/dist/js/materialize.min.js"></script>
-        <script src="https://unpkg.com/vue/dist/vue.min.js"></script>
-        <script src="./index.js"></script>
-        <script src="./docs.js"></script>
-    </body>
+					<div class="col s2 hide-on-small-only">
+						<ul class="section table-of-contents" id="fixed-navigation">
+							<li v-for="component in sortedComponents">
+                                <a :href="`#${component.slug}`">{{ component.name }}</a>
+                            </li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</div>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.16.0/prism.js"></script>
+		<script src="https://unpkg.com/materialize-css/dist/js/materialize.min.js"></script>
+		<script src="https://unpkg.com/vue/dist/vue.min.js"></script>
+		<script src="./index.js"></script>
+		<script src="./docs.js"></script>
+	</body>
 </html>


### PR DESCRIPTION
I added a scroll spy to the right side of the documentation to be able to navigate quickly to the component we want. It is fixed using Pushpin.

**Edit**

I saw you made a similar thing than me, if you prefer your solution just close this PR.