### PR TITLE
removed summary links in doc

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,6 @@
                                 </h2></a
                             >
                             <pre><code class="language-html">{{ component.code }}</code></pre>
-                            <a href="#summary">Summary</a>
                         </div>
                     </div>
 


### PR DESCRIPTION
I removed the summary link in the doc because we have the scrollspy that does a good job now.