### PR TITLE
add component chips

### DIFF
--- a/docs/docs.js
+++ b/docs/docs.js
@@ -44,6 +44,10 @@ window.addEventListener("load", () => {
                     code:
                         '<materialize-column small="12"></materialize-column>\n<materialize-column medium="12"></materialize-column>\n<materialize-column large="12"></materialize-column>\n<materialize-column extra-large="12"></materialize-column>\n<materialize-column offset-small="12"></materialize-column>\n<materialize-column offset-medium="12"></materialize-column>\n<materialize-column offset-large="12"></materialize-column>\n<materialize-column offset-extra-large="12"></materialize-column>\n',
                     name: "Column"
+                },
+                {
+                    code: '<materialize-chips>Tag</materialize-chips>\n<materialize-chips image="/img/jane-doe.jpg" alt="Profile picture of Jane Doe">Jane Doe</materialize-chips>\n<materialize-chips closable>Red</materialize-chips>',
+                    name: "Chips"
                 }
             ]
         },

--- a/src/components/MaterialChips.vue
+++ b/src/components/MaterialChips.vue
@@ -1,0 +1,25 @@
+<template>
+    <div class="chip">
+        <img v-if="image" :src="image" :alt="alt" />
+        <slot />
+        <i v-if="closable" class="material-icons">close</i>
+  </div>
+</template>
+<script>
+export default {
+    props: {
+        image: {
+            type: String,
+            default: ""
+        },
+        alt: {
+            type: String,
+            required: this.image
+        },
+        closable: {
+            type: Boolean,
+            default: false
+        }
+    }
+}
+</script>


### PR DESCRIPTION
New component that maps the HTML-only version of the [Materialize CSS Chips component](https://materializecss.com/chips.html).

Should we call it `chipS` or stick with `chip` without -s? I took the freedom to add an S, because `chip` conotates more with an eletronic chip...

Usage:

```html
<material-chips>Google</material-chips>
<material-chips image="/img/jane-doe.jpg" alt="Profil picture of Jane Doe">Jane</material-chips>
<material-chips closable>Tag</material-chips>
```