### PR TITLE
moved the search bar to the header

### DIFF
--- a/docs/docs.js
+++ b/docs/docs.js
@@ -74,9 +74,10 @@ window.addEventListener("load", () => {
       ],
       scrollspy: {
         instances: null
-      }
+      },
+      searching: false
     },
-    el: "#example",
+    el: "#app",
 
     methods: {
       href(name) {
@@ -102,6 +103,17 @@ window.addEventListener("load", () => {
       initializePrism() {
         // eslint-disable-next-line
 				Prism.highlightAll();
+      },
+      displaySearchBar() {
+        this.searching = true;
+
+        this.$nextTick(function() {
+          this.$refs.searchInput.focus();
+        });
+      },
+      hideSearchBar() {
+        this.searching = false;
+        this.component.name = "";
       }
     },
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,74 +9,90 @@
     <title>Example</title>
   </head>
   <body class="white">
-    <header>
+    <div id="app">
+      <header>
         <div>
-            <nav class="teal darken-1">
-                <div class="row">
-                    <div class="col s12">
-                        <div class="nav-wrapper">
-                            <a href="/vue-materialize" class="brand-logo">vue-materialize</a>
-                        </div>
-                    </div>
+          <nav v-if="!searching" class="teal darken-1">
+            <div class="row">
+              <div class="col s12">
+                <div class="nav-wrapper">
+                  <a href="/vue-materialize" class="brand-logo">vue-materialize</a>
+                  <ul class="right">
+                    <li @click="displaySearchBar">
+                      <a href="javascript:;">
+                        <i class="material-icons">search</i>
+                      </a>
+                    </li>
+                  </ul>
                 </div>
-            </nav>
+              </div>
+            </div>
+          </nav>
+          <nav v-else class="teal darken-1">
+            <div class="nav-wrapper">
+              <form>
+                <div class="input-field">
+                  <input id="component-name" v-model="component.name" ref="searchInput" type="search" required />
+                  <label class="label-icon" for="search">
+                    <i class="material-icons">search</i>
+                  </label>
+                  <i @click="hideSearchBar" class="material-icons">close</i>
+                </div>
+              </form>
+            </div>
+          </nav>
         </div>
-    </header>
-    <main id="example">
-      <div class="container">
-				<div class="row">
-					<div class="col s12 input-field">
-						<input id="component-name" type="text" v-model="component.name">
-						<label for="component-name">Component Name</label>
-					</div>
-				</div>
-        <div class="row">
-          <div class="col s12 m10">
-            <div class="col s12" v-for="component in sortedComponents">
-              <a :href="href(component.name)" :style="style">
-                <h2 :id="id(component.name)" class="flow-text section scrollspy">
-                  <span class="grey-text">#</span>
-                  <span>{{ component.name }}</span>
-                </h2>
-              </a>
-              <pre><code class="language-html">{{ component.code }}</code></pre>
+      </header>
+      <main>
+        <div class="container">
+          <div class="row">
+            <div class="col s12 m10">
+              <div class="col s12" v-for="component in sortedComponents">
+                <a :href="href(component.name)" :style="style">
+                  <h2 :id="id(component.name)" class="flow-text section scrollspy">
+                    <span class="grey-text">#</span>
+                    <span>{{ component.name }}</span>
+                  </h2>
+                </a>
+                <pre><code class="language-html">{{ component.code }}</code></pre>
+              </div>
+            </div>
+            <div class="col s2 hide-on-small-only">
+              <ul class="section table-of-contents" id="fixed-navigation">
+                <li v-for="component in sortedComponents">
+                  <a :href="href(component.name)">{{ component.name }}</a>
+                </li>
+              </ul>
             </div>
           </div>
-          <div class="col s2 hide-on-small-only">
-            <ul class="section table-of-contents" id="fixed-navigation">
-              <li v-for="component in sortedComponents">
-                <a :href="href(component.name)">{{ component.name }}</a>
-              </li>
-            </ul>
+        </div>
+      </main>
+      <footer class="page-footer teal darken-1" style="margin-top: 40vh">
+        <div class="container">
+          <div class="row">
+            <div class="col s12">
+              <h4>vue-materialize</h4>
+              <p>Vue Components for MaterializeCSS</p>
+            </div>
           </div>
         </div>
-      </div>
-    </main>
-		<footer class="page-footer teal darken-1" style="margin-top: 40vh">
-			<div class="container">
-				<div class="row">
-					<div class="col s12">
-                        <h4>vue-materialize</h4>
-                        <p>Vue Components for MaterializeCSS</p>
-					</div>
-				</div>
-			</div>
-			<div class="footer-copyright">
-				<div class="container">
-                    <div class="row">
-                        <div class="col s12 m6">
-                            <span>Copyright &copy; Anwar & Amin NAIRI</span>
-                        </div>
-                        <div class="col s12 hide-on-med-and-up">
-                            <a href="https://github.com/aminnairi/vue-materialize" style="color: inherit;">GitHub Page</a>
-                        </div>
-                        <div class="col m6 right-align hide-on-small-only">
-                            <a href="https://github.com/aminnairi/vue-materialize" style="color: inherit;">GitHub Page</a>
-                        </div>
-                    </div>
-				<div>
-			</div>
-		</footer>
+        <div class="footer-copyright">
+          <div class="container">
+            <div class="row">
+              <div class="col s12 m6">
+                <span>Copyright &copy; Anwar & Amin NAIRI</span>
+              </div>
+              <div class="col s12 hide-on-med-and-up">
+                <a href="https://github.com/aminnairi/vue-materialize" style="color: inherit;">GitHub Page</a>
+              </div>
+              <div class="col m6 right-align hide-on-small-only">
+                <a href="https://github.com/aminnairi/vue-materialize" style="color: inherit;">GitHub Page</a>
+              </div>
+            </div>
+          <div>
+        </div>
+      </footer>
+    </div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.16.0/prism.js"></script>
     <script src="https://unpkg.com/materialize-css/dist/js/materialize.min.js"></script>
     <script src="https://unpkg.com/vue/dist/vue.min.js"></script>


### PR DESCRIPTION
I used the [Materialize CSS "search bar in-navbar"](https://materializecss.com/navbar.html#search-docs) variant to put the search bar inside the navbar instead of below, and I created a new icon to be able to display the in-navbar search input. 