### PR TITLE
make the footer always stick to bottom

### DIFF
--- a/docs/index.css
+++ b/docs/index.css
@@ -4,3 +4,13 @@
     transform: translateX(0) !important;
   }
 }
+
+#app {
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
+}
+
+main {
+  flex: 1 0 auto;
+}


### PR DESCRIPTION
When we search, and the search return no results, the footer get at the middle in desktop screen size. I made it stick to the bottom using the [Materialize CSS adviced tips to fix the footer to the bottom](https://materializecss.com/footer.html#sticky-footer).