### PR TITLE
made css links not to be render blocking

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,10 +4,10 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Vue MaterializeCSS - Vue Components for MaterializeCSS" />
-    <link rel="stylesheet" href="https://unpkg.com/materialize-css/dist/css/materialize.min.css" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.16.0/themes/prism.min.css" />
-    <link rel="stylesheet" href="./index.css" />
+    <link rel="stylesheet" media="none" onload="this.media = 'all';" href="https://unpkg.com/materialize-css/dist/css/materialize.min.css" />
+    <link rel="stylesheet" media="none" onload="this.media = 'all';" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
+    <link rel="stylesheet" media="none" onload="this.media = 'all';" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.16.0/themes/prism.min.css" />
+    <link rel="stylesheet" media="none" onload="this.media = 'all';" href="./index.css" />
     <title>Example</title>
   </head>
   <body class="white">


### PR DESCRIPTION
I added `media="none" onload="this.media = 'all';"` to `<link>` tags to make them non render-blocking at page load. I checked on DevTools and we won 7 points in performance.