### PR TITLE
added display:swap directive to the CDN of the Material icons to improve the percepted font load speed

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
     <meta name="description" content="Vue MaterializeCSS - Vue Components for MaterializeCSS" />
     <meta name="theme-color" content="#00897b" />
     <link rel="stylesheet" media="none" onload="this.media = 'all';" href="https://unpkg.com/materialize-css/dist/css/materialize.min.css" />
-    <link rel="stylesheet" media="none" onload="this.media = 'all';" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
+    <link rel="stylesheet" media="none" onload="this.media = 'all';" href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap" />
     <link rel="stylesheet" media="none" onload="this.media = 'all';" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.16.0/themes/prism.min.css" />
     <link rel="stylesheet" media="none" onload="this.media = 'all';" href="./index.css" />
     <title>Example</title>


### PR DESCRIPTION
I added the `&display:swap` directive to the CDN of the Material Icons link to improve the font load speed and pass one of the Lighthouse score.