### PR TITLE
added defer attribute on script to reduce the critical requests chain depth and improve loading performance

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -114,10 +114,10 @@
       </div>
     </footer>
   </div>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.16.0/prism.js"></script>
-    <script src="https://unpkg.com/materialize-css/dist/js/materialize.min.js"></script>
-    <script src="https://unpkg.com/vue/dist/vue.min.js"></script>
-    <script src="./index.js"></script>
-    <script src="./docs.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.16.0/prism.js" defer="true"></script>
+    <script src="https://unpkg.com/materialize-css/dist/js/materialize.min.js" defer="true"></script>
+    <script src="https://unpkg.com/vue/dist/vue.min.js" defer="true"></script>
+    <script src="./index.js" defer="true"></script>
+    <script src="./docs.js" defer="true"></script>
   </body>
 </html>


### PR DESCRIPTION
I added `defer="true"` to the scripts to parallelize the loading and reduce the requests chain depth. Went from 6 to only 1 "Critical Requests Depth" in LightHouse, improving our performance score.